### PR TITLE
Fixed compilation with OpenCV 4.0

### DIFF
--- a/src/dat_tracker.cpp
+++ b/src/dat_tracker.cpp
@@ -1,3 +1,4 @@
+#include <opencv2/imgproc/imgproc_c.h>
 #include "dat_tracker.hpp"
 
 void DAT_TRACKER::tracker_dat_initialize(cv::Mat I, cv::Rect region){


### PR DESCRIPTION
In OpenCV 4.0 added enums instead integer constants. I added include with old-style constants.